### PR TITLE
Enable multiprocess permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "grunt-contrib-jade": "^0.15.0",
     "gruntify-eslint": "^2.0.0",
     "jade": "^1.11.0"
+  },
+  "permissions": {
+    "multiprocess": "true"
   }
 }


### PR DESCRIPTION
This didn't work the first time I tried it, but it seems to still work with the flag set.

Command to launch in Firefox nightly: `jpm run -b /Applications/FirefoxNightly.app`