### PR TITLE
fix(details): replace target="_blank" on More Info links

### DIFF
--- a/data/panel/panel.js
+++ b/data/panel/panel.js
@@ -22,6 +22,14 @@
     return document.getElementById(id);
   }
 
+  window.DOMPurify.addHook("afterSanitizeAttributes", function (node) {
+    // set all elements owning target to target=_blank
+    // otherwise the purifier will strip them out
+    if ("target" in node && node.getAttribute("href") !== "#") {
+      node.setAttribute("target", "_blank");
+    }
+  });
+
   let list = $id("list");
   let status = $id("status");
   let details = $id("details");


### PR DESCRIPTION
The sanitizer DOMPurify strips out target="_blank" on all links. This code uses the `afterSanitizeAttributes` hook to replace target="_blank" on any link whose href is not "#" so they will open in a new window instead of the devtools panel.

Closes https://github.com/dequelabs/axe-firefox-devtools/issues/47