### PR TITLE
feat: configure application branding

### DIFF
--- a/data/axe-communicator.js
+++ b/data/axe-communicator.js
@@ -23,6 +23,11 @@
    * aXe communicator
    */
   self.port.on("axe.analyze", function () {
+    axe.configure({
+      branding: {
+        application: "axeFirefox"
+      }
+    });
     axe.a11yCheck(document, function (results) {
       self.port.emit("results", results);
     });


### PR DESCRIPTION
@dylanb should we configure aXe application branding in an attach handler or is this sufficient? I tried emitting and listening for an attach event from panel.js but nothing ever occurred. Putting `axe.configure` outside of the message handler threw a ReferenceError, unlike axe-chrome.

Closes https://dequesrc.atlassian.net/browse/WWD-498