### PR TITLE
update axe-core and ext versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
   "engines": {
     "firefox": ">=38.0"
   },
-  "version": "1.0.2",
+  "version": "2.0.2",
   "main": "lib/index.js",
   "dependencies": {
     "dompurify": "^0.8.2",
     "grunt-contrib-copy": "^1.0.0"
   },
   "devDependencies": {
-    "axe-core": "^2.0.5",
+    "axe-core": "^2.1.7",
     "eslint-plugin-mozilla": "0.0.3",
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.6.0",


### PR DESCRIPTION
Pulling in axe-core 2.1.7 and updating the extension to 2.0.2 to match axe-chrome